### PR TITLE
Changing the float output format to show numbers after decimal.

### DIFF
--- a/lib/Dump.php
+++ b/lib/Dump.php
@@ -73,9 +73,13 @@ class Dump {
                   else if ($subject === null) {
                       $subject = Text::shellColor('magenta','null',$colors);
                   }
-                  else if(is_float($subject) || is_double($subject)) {
-                      $format = is_double($subject) ? 'd' : 'f';
-                      $subject = Text::shellColor('cyan', number_format($subject) . ' => :0x'. bin2hex(pack($format, $subject)), $colors);
+                  else if (is_float($subject)) {
+                      if ($subject > 0) {
+                        $formated = number_format($subject);
+                      } else {
+                        $formated = sprintf("%g", $subject);
+                      }
+                      $subject = Text::shellColor('cyan', $formatted . ' => :0x'. bin2hex(pack('d', $subject)), $colors);
                   }
                   else if (is_numeric($subject)) {
                       $subject = Text::shellColor('blue',$subject,$colors);


### PR DESCRIPTION
```number_format()``` doesn't show any digits after the decimal place by default so all floats less than 1 were just printed as 0.
```sprintf("%g", ...)``` shows a float in either decimal or scientific notation whichever is shorter. It's also location aware and will use the appropriate thousands separator.