### PR TITLE
array_merge_recursive_distinct needs replacing with core array_replac…

### DIFF
--- a/lib/Arrays.php
+++ b/lib/Arrays.php
@@ -3,27 +3,6 @@
 class Arrays {
 
     /**
-     * Filters $array by the variadic $keys provided as additional input.
-     *
-     * @example
-     * << $info = array('user' => 'sparks', 'age' => 'infinite', 'make' => 'robocon');
-     * << Arrays::pluck('user', 'robocon')
-     * >> array('user' => 'sparks', 'make' => 'robocon')
-     *
-     * @return $array
-     */
-    public static function pluck($array) {
-        $result = array();
-        $keys = array_slice(func_get_args(),1);
-        foreach($keys as $key) {
-            if(isset($array[$key])) {
-                $result[$key] = $array[$key];
-            }
-        }
-        return $result;
-    }
-
-    /**
      * Gets a value from an array if it exists, otherwise returns $default;
      *
      * Supports dot delimited keys to safely traverse deep arrays.
@@ -74,42 +53,4 @@ class Arrays {
         return $result;
     }
 
-    /**
-     * array_merge_recursive does indeed merge arrays, but it converts values with duplicate
-     * keys to arrays rather than overwriting the value in the first array with the duplicate
-     * value in the second array, as array_merge does. I.e., with array_merge_recursive,
-     * this happens (documented behavior):
-     *
-     * array_merge_recursive(array('key' => 'org value'), array('key' => 'new value'));
-     *     => array('key' => array('org value', 'new value'));
-     *
-     * array_merge_recursive_distinct does not change the datatypes of the values in the arrays.
-     * Matching keys' values in the second array overwrite those in the first array, as is the
-     * case with array_merge, i.e.:
-     *
-     * array_merge_recursive_distinct(array('key' => 'org value'), array('key' => 'new value'));
-     *     => array('key' => array('new value'));
-     *
-     * Parameters are passed by reference, though only for performance reasons. They're not
-     * altered by this function.
-     *
-     * @param array $array1
-     * @param array $array2
-     * @return array
-     * @author Daniel <daniel (at) danielsmedegaardbuus (dot) dk>
-     * @author Gabriel Sobrinho <gabriel (dot) sobrinho (at) gmail (dot) com>
-     */
-    public static function array_merge_recursive_distinct($array1, $array2)
-    {
-      $merged = $array1;
-
-      foreach($array2 as $key => &$value) {
-        if (is_array($value) && isset ( $merged[$key] ) && is_array($merged[$key])) {
-          $merged[$key] = static::array_merge_recursive_distinct($merged[$key], $value);
-        } else {
-          $merged[$key] = $value;
-        }
-      }
-      return $merged;
-    }
 }

--- a/tests/ArraysTests.php
+++ b/tests/ArraysTests.php
@@ -23,7 +23,7 @@ class ArraysTest extends PHPUsableTest
                             'level 2' => 5
                         )
                     );
-                    $test->expect(Arrays::array_merge_recursive_distinct($a, $b))->to->eql(
+                    $test->expect(array_replace_recursive($a, $b))->to->eql(
                         array(
                             'level 1' => array(
                                 'level 2' => 5
@@ -43,7 +43,7 @@ class ArraysTest extends PHPUsableTest
                             'level 2' => array(5)
                         )
                     );
-                    $test->expect(Arrays::array_merge_recursive_distinct($a, $b))->to->eql(
+                    $test->expect(array_replace_recursive($a, $b))->to->eql(
                         array(
                             'level 1' => array(
                                 'level 2' => array(5, 3)


### PR DESCRIPTION
…e_recursive.

For some reason we rolled our own array_merge_recursive_distinct when array_replace_recursive does the exact same thing. This has been available since 5.3.0, so we should just use it. Removed pluck as well, since it is not used anywhere.