### PR TITLE
Defaulting trace depth to 10.

### DIFF
--- a/lib/Trace.php
+++ b/lib/Trace.php
@@ -31,7 +31,7 @@ class Trace {
       ),
       'trace' => array(
         'enabled' => true,
-        'depth' => 1,
+        'depth' => 10,
         'offset' => 0
       ),
       'separator' => ' « ',


### PR DESCRIPTION
I always add ->traceDepth(10) to log lines because I almost always want to see the call stack. If you don't want it for some reason it's easy to change back to 1 with ->traceDepth(1).